### PR TITLE
import flowCore instead of Depends on it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: flowUtils
 Type: Package
 Title: Utilities for flow cytometry
-Version: 1.35.6
+Version: 1.35.7
 Author: J. Spidlen., N. Gopalakrishnan, F. Hahne, B. Ellis, R. Gentleman, M. Dalphin, N. Le Meur, B. Purcell, W. Jiang
 Maintainer: Josef Spidlen <jspidlen@bccrc.ca>
 Description: Provides utilities for flow cytometry data. 
-Depends: R (>= 2.2.0), flowCore (>= 1.32.0)
-Imports: Biobase, graph, methods, stats, utils, flowViz, corpcor, RUnit, XML
+Depends: R (>= 2.2.0)
+Imports: Biobase, graph, methods, stats, utils, flowViz, corpcor, RUnit, XML, flowCore (>= 1.32.0)
 Suggests: gatingMLData
 Collate: AllClasses.R
          gatingML.R

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,6 @@
 export("read.gatingML","testGatingMLCompliance","write.gatingML")
 
-
+import(flowCore)
 importClassesFrom(flowCore, transformReference, unitytransform,
                   workFlow)
 


### PR DESCRIPTION
This will enable other packages (like `CytoML`) to import `flowUtils` without attaching it.
See the details here
http://stackoverflow.com/questions/8637993/better-explanation-of-when-to-use-imports-depends
