### PR TITLE
Remove import of defunct flowCore::workFlow

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,8 +1,7 @@
 export("read.gatingML","testGatingMLCompliance","write.gatingML")
 
 import(flowCore)
-importClassesFrom(flowCore, transformReference, unitytransform,
-                  workFlow)
+importClassesFrom(flowCore, transformReference, unitytransform)
 
 importClassesFrom(methods, ANY, list)
 
@@ -11,7 +10,7 @@ importMethodsFrom(Biobase, description, exprs, pData, sampleNames,
 
 importMethodsFrom(flowCore,action, assign, colnames,
                   "colnames<-", Data, filter, filterDetails, fsApply,
-                  gate, get, head, identifier, keyword, "keyword<-",
+                  gate, head, identifier, keyword, "keyword<-",
                   ncol, nrow, parameters, summary, toTable, transform,
                   tree)
 


### PR DESCRIPTION
The deprecated `workFlow` class will soon be entirely removed from `flowCore`. I believe it was only being used in `workflow2FlowJo.R`, which is already commented out, but `workFlow` is still imported in the namespace. I removed the import of `flowCore::get` for the same reason.

In our case, this commit is needed to avoid issues with RGLab packages depending on `flowUtils`, like `CytoML`. 